### PR TITLE
update to 1.26.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/opentelemetry-exporter-otlp-proto-common-feedstock/pr4/299c469

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/opentelemetry-exporter-otlp-proto-common-feedstock/pr4/299c469

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "opentelemetry-exporter-otlp-proto-http" %}
-{% set version = "1.12.0" %}
+{% set version = "1.26.0" %}
 
 
 package:
@@ -7,26 +7,27 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/opentelemetry-exporter-otlp-proto-http-{{ version }}.tar.gz
-  sha256: 01c7df992fa88ca1c8f130e0263ad0c820da2418b75a176667b75a5ba3a9e266
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/opentelemetry_exporter_otlp_proto_http-{{ version }}.tar.gz
+  sha256: 5801ebbcf7b527377883e6cbbdda35ee712dc55114fff1e93dfee210be56c908
 
 build:
   number: 0
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
 
 requirements:
   host:
     - pip
-    - python >=3.6
+    - python
+    - hatchling
   run:
-    - backoff <3.0.0,>=1.10.0
-    - googleapis-common-protos ~=1.52
-    - opentelemetry-api ~=1.3
-    - opentelemetry-proto ==1.12.0
-    - opentelemetry-sdk ~=1.11
-    - python >=3.6
-    - requests ~=2.7
+    - python
+    - deprecated >=1.2.6
+    - googleapis-common-protos >=1.52,<2.dev0
+    - opentelemetry-api >=1.15,<2.dev0
+    - opentelemetry-proto ==1.26.0
+    - opentelemetry-sdk >=1.26.0,<1.27.dev0
+    - opentelemetry-exporter-otlp-proto-common ==1.26.0
+    - requests >=2.7,<3.dev0
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,6 +43,9 @@ about:
   summary: OpenTelemetry Collector Protobuf over HTTP Exporter
   license: Apache-2.0
   license_file: LICENSE
+  license_family: Apache
+  dev_url: https://github.com/open-telemetry/opentelemetry-python/tree/main/exporter/opentelemetry-exporter-otlp-proto-http
+  doc_url: https://github.com/open-telemetry/opentelemetry-python/tree/main/exporter/opentelemetry-exporter-otlp-proto-http
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
opentelemetry-exporter-otlp-proto-http 1.26.0

**Destination channel:** main

### Links

- PKG-6323
- https://github.com/open-telemetry/opentelemetry-python/tree/v1.26.0/exporter/opentelemetry-exporter-otlp-proto-http
