### PR TITLE
opentelemetry-exporter-otlp-proto-http 1.37.0 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,0 @@
-build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY313 : yes
-

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,19 +1,18 @@
 {% set name = "opentelemetry-exporter-otlp-proto-http" %}
-{% set version = "1.30.0" %}
-
+{% set version = "1.37.0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/opentelemetry_exporter_otlp_proto_http-{{ version }}.tar.gz
-  sha256: c3ae75d4181b1e34a60662a6814d0b94dd33b628bee5588a878bed92cee6abdc
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_')}}-{{ version }}.tar.gz
+  sha256: e52e8600f1720d6de298419a802108a8f5afa63c96809ff83becb03f874e44ac
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
-  skip: True  # [s390x or py<38]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  skip: True  # [py<39]
 
 requirements:
   host:
@@ -22,22 +21,28 @@ requirements:
     - hatchling
   run:
     - python
-    - deprecated >=1.2.6
-    - googleapis-common-protos >=1.52,<2.0.0.dev0
-    - opentelemetry-api >=1.15,<2.0.0.dev0
+    - googleapis-common-protos >=1.52,<2
+    - opentelemetry-api >=1.15,<2
     - opentelemetry-proto =={{ version }}
-    - opentelemetry-sdk >=1.30.0,<1.31.0.dev0
+    - opentelemetry-sdk >=1.37.0,<1.38
     - opentelemetry-exporter-otlp-proto-common =={{ version }}
-    - requests >=2.7,<3.0.0dev0
+    - requests >=2.7,<3
+    - typing-extensions >=4.5.0
 
+# E   ModuleNotFoundError: No module named 'opentelemetry.test'
+# https://pypi.org/project/opentelemetry-test-utils, not in the main channel.
+{% set ignore_tests = " --ignore=tests/metrics/test_otlp_metrics_exporter.py" %}
 test:
+  source_files:
+    - tests
   imports:
-    - opentelemetry
-    - opentelemetry.exporter
+    - opentelemetry.exporter.otlp.proto.http
   commands:
     - pip check
+    - pytest -v tests {{ ignore_tests }}
   requires:
     - pip
+    - pytest >=7.4.4
 
 about:
   home: https://github.com/open-telemetry/opentelemetry-python/tree/main/exporter/opentelemetry-exporter-otlp-proto-http


### PR DESCRIPTION
opentelemetry-exporter-otlp-proto-http 1.37.0 

**Destination channel:** Defaults

### Links

- [PKG-9824]
- dev_url:        https://github.com/open-telemetry/opentelemetry-python/tree/v1.37.0
- conda_forge:    https://github.com/conda-forge/opentelemetry-exporter-otlp-proto-http-feedstock
- pypi:           https://pypi.org/project/opentelemetry-exporter-otlp-proto-http/1.37.0
- pypi inspector: https://inspector.pypi.io/project/opentelemetry-exporter-otlp-proto-http/1.37.0

### Explanation of changes:

- new version number


[PKG-9824]: https://anaconda.atlassian.net/browse/PKG-9824?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ