### PR TITLE
opentelemetry-exporter-otlp-proto-http 1.38.0 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "opentelemetry-exporter-otlp-proto-http" %}
-{% set version = "1.37.0" %}
+{% set version = "1.38.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,12 +7,12 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_')}}-{{ version }}.tar.gz
-  sha256: e52e8600f1720d6de298419a802108a8f5afa63c96809ff83becb03f874e44ac
+  sha256: f16bd44baf15cbe07633c5112ffc68229d0edbeac7b37610be0b2def4e21e90b
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   skip: True  # [py<39]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:
@@ -24,7 +24,7 @@ requirements:
     - googleapis-common-protos >=1.52,<2
     - opentelemetry-api >=1.15,<2
     - opentelemetry-proto =={{ version }}
-    - opentelemetry-sdk >=1.37.0,<1.38
+    - opentelemetry-sdk >=1.38.0,<1.39.0.dev
     - opentelemetry-exporter-otlp-proto-common =={{ version }}
     - requests >=2.7,<3
     - typing-extensions >=4.5.0
@@ -50,11 +50,11 @@ test:
 
 about:
   home: https://github.com/open-telemetry/opentelemetry-python/tree/main/exporter/opentelemetry-exporter-otlp-proto-http
-  summary: OpenTelemetry Collector Protobuf over HTTP Exporter
-  description: This library allows to export data to the OpenTelemetry Collector using the OpenTelemetry Protocol using Protobuf over HTTP.
   license: Apache-2.0
   license_file: LICENSE
   license_family: Apache
+  summary: OpenTelemetry Collector Protobuf over HTTP Exporter
+  description: This library allows to export data to the OpenTelemetry Collector using the OpenTelemetry Protocol using Protobuf over HTTP.
   dev_url: https://github.com/open-telemetry/opentelemetry-python/tree/main/exporter/opentelemetry-exporter-otlp-proto-http
   doc_url: https://github.com/open-telemetry/opentelemetry-python/tree/main/exporter/opentelemetry-exporter-otlp-proto-http
 


### PR DESCRIPTION
opentelemetry-exporter-otlp-proto-http 1.38.0 

**Destination channel:** Defaults

### Links

- [PKG-10846]
- dev_url:        https://github.com/open-telemetry/opentelemetry-python/tree/v1.38.0
- conda_forge:    https://github.com/conda-forge/opentelemetry-exporter-otlp-proto-http-feedstock
- pypi:           https://pypi.org/project/opentelemetry-exporter-otlp-proto-http/1.38.0
- pypi inspector: https://inspector.pypi.io/project/opentelemetry-exporter-otlp-proto-http/1.38.0

### Explanation of changes:

- new version number


[PKG-10846]: https://anaconda.atlassian.net/browse/PKG-10846?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ