### PR TITLE
opentelemetry-exporter-otlp-proto-http 1.12.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+upload_channels:
+  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,41 +1,48 @@
 {% set name = "opentelemetry-exporter-otlp-proto-http" %}
 {% set version = "1.12.0" %}
 
-
 package:
-  name: {{ name|lower }}
+  name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/opentelemetry-exporter-otlp-proto-http-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 01c7df992fa88ca1c8f130e0263ad0c820da2418b75a176667b75a5ba3a9e266
 
 build:
-  number: 0
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  number: 4
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  skip: true  # [py<36]
 
 requirements:
   host:
     - pip
-    - python >=3.6
+    - python
+    - wheel
+    - setuptools <81
   run:
-    - backoff <3.0.0,>=1.10.0
-    - googleapis-common-protos ~=1.52
-    - opentelemetry-api ~=1.3
-    - opentelemetry-proto ==1.12.0
-    - opentelemetry-sdk ~=1.11
-    - python >=3.6
-    - requests ~=2.7
+    - python
+    - requests >=2.7,<3
+    - googleapis-common-protos >=1.52,<2
+    - opentelemetry-api >=1.3,<2
+    - opentelemetry-sdk >=1.11,<2
+    - opentelemetry-proto =={{ version }}
+    - backoff >=1.10.0,<2.0.0  # [py<37]
+    - backoff >=1.10.0,<3.0.0  # [py>=37]
+    - setuptools <81
 
 test:
+  source_files:
+    - tests
   imports:
     - opentelemetry
     - opentelemetry.exporter
   commands:
     - pip check
+    - pytest -v tests
   requires:
     - pip
+    - pytest
 
 about:
   home: https://github.com/open-telemetry/opentelemetry-python/tree/main/exporter/opentelemetry-exporter-otlp-proto-http

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - requests >=2.7,<3
     - googleapis-common-protos >=1.52,<2
     - opentelemetry-api >=1.3,<2
-    # Update upper-bound to fix error in tests
+    # Pin concrete version to fix error in tests:
     # E ImportError: cannot import name 'LogData' from 'opentelemetry.sdk._logs.export'
     - opentelemetry-sdk =={{ version }}
     - opentelemetry-proto =={{ version }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,8 @@ source:
 build:
   number: 4
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
-  skip: true  # [py<36]
+  # Not support protobuf >4.x
+  skip: true  # [py<36 or py>312]
 
 requirements:
   host:
@@ -25,7 +26,9 @@ requirements:
     - requests >=2.7,<3
     - googleapis-common-protos >=1.52,<2
     - opentelemetry-api >=1.3,<2
-    - opentelemetry-sdk >=1.11,<2
+    # Update upper-bound to fix error in tests
+    # E ImportError: cannot import name 'LogData' from 'opentelemetry.sdk._logs.export'
+    - opentelemetry-sdk =={{ version }}
     - opentelemetry-proto =={{ version }}
     - backoff >=1.10.0,<2.0.0  # [py<37]
     - backoff >=1.10.0,<3.0.0  # [py>=37]


### PR DESCRIPTION
opentelemetry-exporter-otlp-proto-http 1.12.0

**Destination channel:** Snowflake

### Links

- [PKG-14906](https://anaconda.atlassian.net/browse/PKG-14906) 
- [Upstream repository](https://inspector.pypi.io/project/opentelemetry-exporter-otlp-proto-http/1.12.0)

### Explanation of changes:

- rebuild


[PKG-14906]: https://anaconda.atlassian.net/browse/PKG-14906?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ